### PR TITLE
Fix nan handling

### DIFF
--- a/float16.go
+++ b/float16.go
@@ -122,7 +122,7 @@ func FromFloat64(f float64) Float16 {
 			return Float16(sign | (mask16 << shift16))
 		} else {
 			// NaN
-			return Float16(sign | uvnan | uint16(frac>>(shift64-shift16)&fracMask16))
+			return Float16(uvnan)
 		}
 	}
 

--- a/float16.go
+++ b/float16.go
@@ -114,9 +114,9 @@ func FromFloat64(f float64) Float16 {
 	b := math.Float64bits(f)
 	sign := uint16((b & signMask64) >> (64 - 16))
 	exp := int((b >> shift64) & mask64)
-	frac := b & fracMask64
 
 	if exp == mask64 {
+		frac := b & fracMask64
 		if frac == 0 {
 			// infinity or negative infinity
 			return Float16(sign | (mask16 << shift16))

--- a/float16_test.go
+++ b/float16_test.go
@@ -161,7 +161,11 @@ func TestFromFloat64_TestFloat(t *testing.T) {
 	for _, tt := range f64ToF16 {
 		f64 := math.Float64frombits(tt.f64)
 		got := FromFloat64(f64)
-		if got.Bits() != tt.f16 {
+		want := FromBits(tt.f16)
+		if got.IsNaN() && want.IsNaN() {
+			continue
+		}
+		if got != want {
 			t.Errorf("%016x: expected %04x, got %04x", tt.f64, tt.f16, got.Bits())
 		}
 	}
@@ -285,23 +289,24 @@ func TestFloat64_Specials(t *testing.T) {
 }
 
 func BenchmarkFromFloat32(b *testing.B) {
-	f := float32(1) / 3
+	r := newXorshift32()
 	for i := 0; i < b.N; i++ {
-		runtime.KeepAlive(FromFloat32(f))
+		runtime.KeepAlive(FromFloat32(r.Float32()))
 	}
 }
 
 func BenchmarkFloat32(b *testing.B) {
-	f := Float16(0x3555)
+	r := newXorshift32()
 	for i := 0; i < b.N; i++ {
+		f, _ := r.Float16Pair()
 		runtime.KeepAlive(f.Float32())
 	}
 }
 
 func BenchmarkFromFloat64(b *testing.B) {
-	f := float64(1) / 3
+	r := newXorshift32()
 	for i := 0; i < b.N; i++ {
-		runtime.KeepAlive(FromFloat64(f))
+		runtime.KeepAlive(FromFloat64(r.Float64()))
 	}
 }
 

--- a/math_test.go
+++ b/math_test.go
@@ -41,6 +41,17 @@ func (x *xorshift32) Float16Pair() (Float16, Float16) {
 	return a, b
 }
 
+func (x *xorshift32) Float32() float32 {
+	bits := x.Uint32()
+	return math.Float32frombits(bits)
+}
+
+func (x *xorshift32) Float64() float64 {
+	bits := uint64(x.Uint32()) << 32
+	bits |= uint64(x.Uint32())
+	return math.Float64frombits(bits)
+}
+
 func BenchmarkFloat16Pair(b *testing.B) {
 	x := newXorshift32()
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/shogo82148/float16
               │  .old.txt   │              .new.txt              │
               │   sec/op    │   sec/op     vs base               │
FromFloat64-10   10.80n ± 0%   10.77n ± 0%  -0.23% (p=0.004 n=10)
Float64-10       4.038n ± 0%   4.047n ± 3%       ~ (p=0.382 n=10)
geomean          6.603n        6.604n       +0.00%
```