### PR TITLE
add Go 1.24 to the build matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ jobs:
       fail-fast: false
       matrix:
         go:
+          - "1.24"
+          - "1.23"
+          - "1.22"
           - "1.21"
         arch:
           - amd64
@@ -31,7 +34,6 @@ jobs:
       - name: upload coverage
         uses: codecov/codecov-action@v5
         with:
-          file: ./coverage.txt
           flags: ${{ matrix.go }}
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded testing to cover additional runtime versions for improved reliability.
- **Chores**
  - Updated the coverage upload process to streamline handling of coverage data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->